### PR TITLE
Win e2e with setting PR check status

### DIFF
--- a/.github/workflows/windows-e2e.yml
+++ b/.github/workflows/windows-e2e.yml
@@ -26,17 +26,56 @@ jobs:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: gh_context
 
-      - name: Add status in PR checks
-        run: |
-          set -Eeuo pipefail
-          # OWNER_REPO=$(cat gh_context.json | jq -r '.repository')
-          AFTER=$(cat gh_context.json | jq -r '.event.after')
-          echo ${AFTER}
-          echo ${{ github.repository }}
+      - name: Test Report
+        id: test-report
+        uses: mikepenz/action-junit-report@v4
+        if: always() # always run even if the previous step fails
+        with:
+          fail_on_failure: true
+          include_passed: true
+          detailed_summary: true
+          require_tests:  true
+          report_paths: '**/*.xml'
 
+      - name: Upload e2e results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: E2E-results-windows-${{ matrix.windows-version }}${{ matrix.windows-featurepack }}
+          path: |
+            **/*.xml
+            **/*.results
+            **/*.log
+
+      - name: Add variables to GITHUB_ENV
+        run: |
+          # SHA used as ID to correlate artifacts between buld-tests, windows-installer, and windows-e2e workflows
+          echo "SHA=$(cat gh_context.json | jq -r '.sha')" >> "$GITHUB_ENV"
+
+          COMMIT_ID=$(cat gh_context.json | jq -r '.event.after')
+          # if this is a new PR, .event.after is empty, use .sha instead in that case
+          if [[ -z "$COMMIT_ID"]]; then
+            COMMIT_ID=$(cat gh_context.json | jq -r '.sha')
+          fi
+
+          # COMMIT_SHA used to identify commit whose status needs to be set to reflect test results
+          echo "COMMIT_SHA=$COMMIT_ID" >> "$GITHUB_ENV"
+      
+      - name: Update status of the PR check
+        run: |
+
+          OUTCOME="success"
+          if [[ ${{steps.test-report.outcome}} != "success"]]; then 
+            OUTCOME="failure";
+          fi
+
+          DESCRIPTION="Finished e2e on Windows"
+          CONTEXT="win-ci-e2e"
+
+          # post result to commit status
           curl -L -v \
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ github.token }}" \
-          https://api.github.com/repos/${{ github.repository }}/statuses/${AFTER} \
-          -d '{"state":"pending", "description":"Running e2e on Windows", "context":"win-ci-e2e"}'
+          https://api.github.com/repos/${{ github.repository }}/statuses/${{ env.COMMIT_SHA }} \
+          -d '{"state":${OUTCOME}, "description":${DESCRIPTION}, "context":${CONTEXT}, "target_url":${{ github.run_id }}}'


### PR DESCRIPTION
1. Set status based on success/fail of the tests. Taking status from 'test-results' step.
2. Use `github.sha` whenever `github.event.after` not available -- is that a good sha to update status of? 
3. Add link to the workflow-run page (via `run_id`) to see the results directly from the status.

To test: Merge this and submit create a dummy PR from stranger's fork. Then watch its status.

If this works, the PR on crc-org/crc is finalized.